### PR TITLE
Fix adding categories on articles creation, fix unique category name

### DIFF
--- a/backend/src/main/java/com/esiea/esieadelta/controller/CategoryController.java
+++ b/backend/src/main/java/com/esiea/esieadelta/controller/CategoryController.java
@@ -51,10 +51,17 @@ public class CategoryController {
 	@PostMapping("")
 	public ResponseEntity<CompleteCategory> addCategory(@RequestBody Category category) {
 		try {
-			CompleteCategory completeCategory = categoryService.createCategory(category);
+			CompleteCategory completeCategory;
+			if ( categoryService.categoryNameExists(category.getName()) ) {
+				completeCategory = categoryService.getCategory(categoryService.findCategoryByName(category.getName()).getId());
+			} else {
+				completeCategory= categoryService.createCategory(category);				
+			}
 			return new ResponseEntity<CompleteCategory>(completeCategory, HttpStatus.OK);			
 		} catch ( NotAllowedException e ) {
 			return new ResponseEntity<>( HttpStatus.METHOD_NOT_ALLOWED);
+		} catch (NotFoundException e) {
+			return new ResponseEntity<>( HttpStatus.NOT_FOUND);
 		}
 	}
 	

--- a/backend/src/main/java/com/esiea/esieadelta/model/Article.java
+++ b/backend/src/main/java/com/esiea/esieadelta/model/Article.java
@@ -4,11 +4,15 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
@@ -27,7 +31,17 @@ public class Article {
 	@DateTimeFormat( pattern = "yyyy-MM-dd" )
 	private Date date;
 	private String content;
-	@ManyToMany( mappedBy = "articles" )
+	@ManyToMany( 
+		fetch = FetchType.LAZY,
+		cascade = {
+			CascadeType.MERGE
+		}
+	)
+	@JoinTable(
+		name = "category_article",
+		joinColumns = @JoinColumn( name = "article_id" ),
+		inverseJoinColumns = @JoinColumn( name = "category_id" )
+	)
 	private List<Category> categories = new ArrayList<>();
 	
 	public Integer getId() {

--- a/backend/src/main/java/com/esiea/esieadelta/model/Category.java
+++ b/backend/src/main/java/com/esiea/esieadelta/model/Category.java
@@ -3,39 +3,29 @@ package com.esiea.esieadelta.model;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 @Entity
-@Table( name = "categories" )
+@Table( 
+	name = "categories",
+	uniqueConstraints = { @UniqueConstraint( 	columnNames = { "name" } ) }
+)
 public class Category {
 
 	@Id
 	@GeneratedValue( strategy = GenerationType.IDENTITY )
 	@Column( name = "category_id" )
 	private Integer id;
+	@Column( name = "name", unique = true )
 	private String name;
-	@ManyToMany( 
-		fetch = FetchType.LAZY,
-		cascade = {
-			CascadeType.PERSIST,
-			CascadeType.MERGE
-		}
-	)
-	@JoinTable(
-		name = "category_article",
-		joinColumns = @JoinColumn( name = "category_id" ),
-		inverseJoinColumns = @JoinColumn( name = "article_id" )
-	)
+	@ManyToMany( mappedBy = "categories" )
 	private List<Article> articles = new ArrayList<>();
 	
 	public Integer getId() {

--- a/backend/src/main/java/com/esiea/esieadelta/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/esiea/esieadelta/repository/CategoryRepository.java
@@ -6,4 +6,5 @@ import com.esiea.esieadelta.model.Category;
 
 public interface CategoryRepository extends CrudRepository<Category, Integer> {
 
+	public Iterable<Category> findByName(String name);
 }

--- a/backend/src/main/java/com/esiea/esieadelta/service/CategoryService.java
+++ b/backend/src/main/java/com/esiea/esieadelta/service/CategoryService.java
@@ -46,6 +46,14 @@ public class CategoryService {
 		return categoryRepository.findById(id);
 	}
 	
+	public Boolean categoryNameExists(String name) {
+		return categoryRepository.findByName(name).iterator().hasNext();
+	}
+
+	public Category findCategoryByName(String name) {
+		return categoryRepository.findByName(name).iterator().next();
+	}
+	
 	public CompleteCategory updateCategory(Category category) throws NotFoundException {
 		getCategory(category.getId());
 		return upsertCategory(category);


### PR DESCRIPTION
We can now add Categories to Articles on **creation**. Some checks were added to ensure all categories have different names (i.e. new ones can't be named the same as already existing ones)